### PR TITLE
Use Get function to access gitlab event header to prevent crashes

### DIFF
--- a/input/gitlab.go
+++ b/input/gitlab.go
@@ -174,7 +174,7 @@ func (m GitlabModule) GetHandler() http.HandlerFunc {
 		defer req.Body.Close()
 		decoder := json.NewDecoder(req.Body)
 
-		var eventType = req.Header["X-Gitlab-Event"][0]
+		var eventType = req.Header.Get("X-Gitlab-Event")
 
 		type Project struct {
 			Name      string `json:"name"`


### PR DESCRIPTION
Currently CptHook crashes when sending requests without "X-Gitlab-Event" header.
The Header.Get function returns the first header value or "" if the header is missing.