### PR TITLE
Track state of IRC client

### DIFF
--- a/irc.go
+++ b/irc.go
@@ -91,7 +91,7 @@ func ircConnection(config *viper.Viper, channelList []string) {
 	for {
 		if err := client.Connect(); err != nil {
 			log.Warnf("Connection to %s terminated: %s", client.Server(), err)
-			log.Warn("Reconnecting to in 30 seconds...")
+			log.Warn("Reconnecting in 30 seconds...")
 			time.Sleep(30 * time.Second)
 		}
 	}


### PR DESCRIPTION
I added a RWMutex to track if the IRC client object is currently connected. On connect and disconnect a write-lock is set which forbids any access to the client for the other parts of CptHook. The parts which access the client just use read-locks so they don't interfere which each other, but get blocked if a write-lock is currently in place.

This should fix #20 and #36 which are both resulting from the fact that CptHook tries to do stuff with the client while it is disconnected.