### PR TITLE
gitlab: use HookActions map only if it is necessary

### DIFF
--- a/input/gitlab.go
+++ b/input/gitlab.go
@@ -337,7 +337,9 @@ func (m GitlabModule) GetHandler() http.HandlerFunc {
 				return
 			}
 
-			mergeEvent.Merge.Action = HookActions[mergeEvent.Merge.Action]
+			if action, ok := HookActions[mergeEvent.Merge.Action]; ok {
+				mergeEvent.Merge.Action = action
+			}
 
 			mergeTemplate.Execute(&buf, &mergeEvent)
 
@@ -350,7 +352,9 @@ func (m GitlabModule) GetHandler() http.HandlerFunc {
 				return
 			}
 
-			issueEvent.Issue.Action = HookActions[issueEvent.Issue.Action]
+			if action, ok := HookActions[issueEvent.Issue.Action]; ok {
+				issueEvent.Issue.Action = action
+			}
 
 			issueTemplate.Execute(&buf, &issueEvent)
 


### PR DESCRIPTION
Since Gitlab 13.2 an approve and unapprove Action is available in Core: https://gitlab.com/help/user/project/merge_requests/merge_request_approvals#optional-approvals-core-only

The intent with this PR is to only use the Value form the HookAction if a value is found. Whether this is really what happens must be tested by someone. I have no environment in which I could easily test this.