### PR TITLE
Improve handling of connection issues 1/

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,8 +1,5 @@
-# This is an example goreleaser.yaml file with some sane defaults.
-# Make sure to check the documentation at http://goreleaser.com
 builds:
--
-  env:
+- env:
     - CGO_ENABLED=0
   goos:
     - linux
@@ -11,13 +8,13 @@ builds:
     - amd64
     - arm64
 
-archive:
-  replacements:
-    linux: Linux
-    amd64: x86_64
-  files:
-    - LICENSE
-    - cpthook.yml.example
+archives:
+  - replacements:
+      linux: Linux
+      amd64: x86_64
+    files:
+      - LICENSE
+      - cpthook.yml.example
 
 checksum:
   name_template: 'checksums.txt'
@@ -30,5 +27,5 @@ changelog:
   filters:
     exclude:
     - '^docs:'
-    - '^test:'
+    - '^test_data:'
 

--- a/cpthook.yml.example
+++ b/cpthook.yml.example
@@ -5,11 +5,11 @@ logging:
     level: "INFO"
 
 irc:
-    host: "irc.hackint.eu"
-    port: 6667
+    host: "irc.hackint.org"
+    port: 6697
     ssl:
         enabled: true
-        cafile: "/etc/ssl/hackint.pem"
+        cafile: "/etc/ssl/certs/ca-certificates.crt"
         client_cert:
             certfile: "/home/bot/bot.cert"
             keyfile: "/home/bot/bot.key"


### PR DESCRIPTION
There was a problem in the automatic reconnect loop: If the connection to the IRC server is dropped it will not be reestablished because the call to `client.Server()` blocks forever. This is fixed by not calling it at this point. But there are other issues we have to tackle.

The first one is our locking. We still have a big issue here if the following happens:

- if the connection goes down, `client.Connect()` returns an error
- we acquire the lock: `clientLock.Lock()`
- we sleep some time
- we call `client.Connect()` again and it fails again because our Internet is still broken
- As our handler (CONNECTED) was not called, the lock is still in use
- we hang here forever

https://github.com/fleaz/CptHook/blob/4d1839ae1aa619f6648c7aa03d412722d378def5/irc.go#L121-L129

If we want to rewrite the lock logic, we have to think about two scenarios:

1) How do we handle the time between irc-connection-is-down and the-library-knows-that-the-connection-is-down?
The library sends continuously a PING (every 20 seconds is the smallest time interval we can use). If now() - time_last(PONG) is > 60 seconds, the connection goes in state disconnected. Then `Connect()` returns and we reconnect.

2) What happens if the connection to the IRC server is down, but our http server works and is used? We can

- send a 500 because the IRC connection is down (if we know it; good for alertmanager, probably bad for other things that don't automatically resend)
- handle the received data in a go routine and always return a 200 (never blocks, but we have to buffer the messages until IRC is up again)
- we keep the logic as it is and increase the channel size. Right now, http connections are held open if we cannot write into the channel (because the IRC sender does not work and stops reading from the channel)